### PR TITLE
Typeset `bul.tex` using TeX Live 2023 rather than 2020

### DIFF
--- a/Dockerfile.TL2020
+++ b/Dockerfile.TL2020
@@ -1,5 +1,6 @@
 FROM texlive/texlive:TL2020-historic
 COPY --from=texlive/texlive:latest /usr/local/texlive/2023/texmf-dist/tex/latex/csbulletin/* /usr/local/texlive/2020/texmf-dist/tex/latex/csbulletin/
+RUN sed -i s/,nopatch=item// /usr/local/texlive/2020/texmf-dist/tex/latex/csbulletin/csbulletin.cls
 RUN luaotfload-tool -u || true
 RUN cp "$(find /usr/local/texlive -name texlive-fontconfig.conf)" /etc/fonts/conf.d/09-texlive-fonts.conf || true
 RUN fc-cache -fsv

--- a/Dockerfile.TL2020
+++ b/Dockerfile.TL2020
@@ -1,4 +1,5 @@
 FROM texlive/texlive:TL2020-historic
+COPY --from=texlive/texlive:latest /usr/local/texlive/2023/texmf-dist/tex/latex/csbulletin/* /usr/local/texlive/2020/texmf-dist/tex/latex/csbulletin/
 RUN luaotfload-tool -u || true
 RUN cp "$(find /usr/local/texlive -name texlive-fontconfig.conf)" /etc/fonts/conf.d/09-texlive-fonts.conf || true
 RUN fc-cache -fsv

--- a/Dockerfile.TL2022
+++ b/Dockerfile.TL2022
@@ -1,4 +1,5 @@
 FROM texlive/texlive:TL2022-historic
+COPY --from=texlive/texlive:latest /usr/local/texlive/2023/texmf-dist/tex/latex/csbulletin/* /usr/local/texlive/2022/texmf-dist/tex/latex/csbulletin/
 RUN luaotfload-tool -u || true
 RUN cp "$(find /usr/local/texlive -name texlive-fontconfig.conf)" /etc/fonts/conf.d/09-texlive-fonts.conf || true
 RUN fc-cache -fsv


### PR DESCRIPTION
Closes #26.